### PR TITLE
Complete scope for CMS1-7

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -10,7 +10,9 @@
                     "title": "Title",
                     "modules": "Modules",
                     "addModule": "Add Module",
-                    "noModules": "No modules yet"
+                    "noModules": "No modules yet",
+                    "addLecture": "Add Lecture",
+                    "noLectures": "No lectures yet"
                 }
             }
         },

--- a/frontend/public/locales/es/translation.json
+++ b/frontend/public/locales/es/translation.json
@@ -10,7 +10,9 @@
                     "title": "Título",
                     "modules": "Módulos",
                     "addModule": "Agregar Módulo",
-                    "noModules": "Aún no hay módulos"
+                    "noModules": "Aún no hay módulos",
+                    "addLecture": "Agregar clase",
+                    "noLectures": "Aún no hay clases"
                 }
             }
         },

--- a/frontend/src/components/draggable/DraggableItem.tsx
+++ b/frontend/src/components/draggable/DraggableItem.tsx
@@ -8,20 +8,19 @@ import { Item } from './types';
 interface Props {
     item: Item;
     children: React.ReactNode;
+    itemClass: String;
 }
 
-const DraggableItem = ({ item, children }: Props) => {
+const DraggableItem = ({ item, children, itemClass }: Props) => {
     const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id: item.id });
     const dndStyle = {
         transform: transform ? CSS.Transform.toString(transform) : undefined,
         transition,
     };
+
+    const classes = `d-flex align-items-center px-2 py-2 text-dark my-2 g-0 ${itemClass}`;
     return (
-        <Row
-            className="d-flex align-items-center px-2 py-2 text-dark my-2 __draggable-item"
-            ref={setNodeRef}
-            style={{ height: '2.8rem', ...dndStyle }}
-        >
+        <Row className={classes} ref={setNodeRef} style={{ height: '2.8rem', ...dndStyle }}>
             <Col xs="auto" className="px-1 __draggable-selection" {...attributes} {...listeners}>
                 <BsList />
             </Col>

--- a/frontend/src/components/draggable/_draggableItem.scss
+++ b/frontend/src/components/draggable/_draggableItem.scss
@@ -1,12 +1,17 @@
 @use '@/assets/scss/style.scss' as *;
 
-.__draggable-item {
+.__draggable-item-darkGrey {
     background-color: $gray-300;
-    .__draggable-selection {
-        cursor: grab;
-        touch-action: none;
-        &:active {
-            cursor: grabbing;
-        }
+}
+
+.__draggable-item-lightGrey {
+    background-color: $gray-200;
+}
+
+.__draggable-selection {
+    cursor: grab;
+    touch-action: none;
+    &:active {
+        cursor: grabbing;
     }
 }

--- a/frontend/src/views/instructors/courses/components/ItemActionButtons.tsx
+++ b/frontend/src/views/instructors/courses/components/ItemActionButtons.tsx
@@ -1,0 +1,55 @@
+import React, { ReactNode } from 'react';
+import { Button, Col } from 'react-bootstrap';
+import { useTranslation } from 'react-i18next';
+import { BsPencilSquare, BsTrash } from 'react-icons/bs';
+
+interface Item {
+    id: string;
+    title: string;
+}
+
+interface ItemActionButtonsProps {
+    item: Item;
+    deleteMode: boolean;
+    onToggleDeleteMode: (moduleId: string, editMode: boolean) => void;
+    onDelete: (id: string) => void;
+    children?: ReactNode;
+}
+
+const ItemActionButtons: React.FC<ItemActionButtonsProps> = ({
+    item,
+    deleteMode,
+    onToggleDeleteMode,
+    onDelete,
+    children,
+}) => {
+    const { t } = useTranslation();
+    return (
+        <>
+            <Col xs="auto" className="d-flex gap-3 px-1 ">
+                {deleteMode ? (
+                    <>
+                        <div className="__module-item-deleteButton">
+                            <Button size="sm" variant="link" className="p-0 m-0" onClick={() => onDelete(item.id)}>
+                                {t('views.common.delete')}
+                            </Button>
+                        </div>
+                        <div className="__module-item-cancelButton" onClick={() => onToggleDeleteMode(item.id, false)}>
+                            <Button size="sm" variant="link" className="p-0 m-0">
+                                {t('views.common.cancel')}
+                            </Button>
+                        </div>
+                    </>
+                ) : (
+                    <>
+                        <BsPencilSquare role="button" />
+                        <BsTrash role="button" onClick={() => onToggleDeleteMode(item.id, true)} />
+                        {children}
+                    </>
+                )}
+            </Col>
+        </>
+    );
+};
+
+export default ItemActionButtons;

--- a/frontend/src/views/instructors/courses/components/ItemActionButtons.tsx
+++ b/frontend/src/views/instructors/courses/components/ItemActionButtons.tsx
@@ -2,19 +2,12 @@ import React, { ReactNode } from 'react';
 import { Button, Col } from 'react-bootstrap';
 import { useTranslation } from 'react-i18next';
 import { BsPencilSquare, BsTrash } from 'react-icons/bs';
+import { ModuleItemProps, Module } from '../types';
 
-interface Item {
-    id: string;
-    title: string;
-}
-
-interface ItemActionButtonsProps {
-    item: Item;
-    deleteMode: boolean;
-    onToggleDeleteMode: (moduleId: string, editMode: boolean) => void;
-    onDelete: (id: string) => void;
+type ItemActionButtonsProps = Pick<ModuleItemProps, 'deleteMode' | 'onToggleDeleteMode' | 'onDelete'> & {
     children?: ReactNode;
-}
+    item: Module;
+};
 
 const ItemActionButtons: React.FC<ItemActionButtonsProps> = ({
     item,

--- a/frontend/src/views/instructors/courses/components/ItemActionButtons.tsx
+++ b/frontend/src/views/instructors/courses/components/ItemActionButtons.tsx
@@ -2,32 +2,42 @@ import React, { ReactNode } from 'react';
 import { Button, Col } from 'react-bootstrap';
 import { useTranslation } from 'react-i18next';
 import { BsPencilSquare, BsTrash } from 'react-icons/bs';
-import { ModuleItemProps, Module } from '../types';
+import { ModuleItemProps, Module, Lecture } from '../types';
 
-type ItemActionButtonsProps = Pick<ModuleItemProps, 'deleteMode' | 'onToggleDeleteMode' | 'onDelete'> & {
+type ItemActionButtonsProps<T extends Module | Lecture> = Pick<
+    ModuleItemProps,
+    'isDeleting' | 'toggleDeleteMode' | 'onDeleteItem'
+> & {
     children?: ReactNode;
-    item: Module;
+    item: T;
+    setItems: React.Dispatch<React.SetStateAction<T[]>>;
 };
 
-const ItemActionButtons: React.FC<ItemActionButtonsProps> = ({
+const ItemActionButtons = <T extends Module | Lecture>({
     item,
-    deleteMode,
-    onToggleDeleteMode,
-    onDelete,
+    isDeleting,
+    toggleDeleteMode,
+    onDeleteItem,
     children,
-}) => {
+    setItems,
+}: ItemActionButtonsProps<T>) => {
     const { t } = useTranslation();
     return (
         <>
             <Col xs="auto" className="d-flex gap-3 px-1 ">
-                {deleteMode ? (
+                {isDeleting ? (
                     <>
                         <div className="__module-item-deleteButton">
-                            <Button size="sm" variant="link" className="p-0 m-0" onClick={() => onDelete(item.id)}>
+                            <Button
+                                size="sm"
+                                variant="link"
+                                className="p-0 m-0"
+                                onClick={() => onDeleteItem(item.id, setItems)}
+                            >
                                 {t('views.common.delete')}
                             </Button>
                         </div>
-                        <div className="__module-item-cancelButton" onClick={() => onToggleDeleteMode(item.id, false)}>
+                        <div className="__module-item-cancelButton" onClick={() => toggleDeleteMode(item.id, false)}>
                             <Button size="sm" variant="link" className="p-0 m-0">
                                 {t('views.common.cancel')}
                             </Button>
@@ -36,7 +46,7 @@ const ItemActionButtons: React.FC<ItemActionButtonsProps> = ({
                 ) : (
                     <>
                         <BsPencilSquare role="button" />
-                        <BsTrash role="button" onClick={() => onToggleDeleteMode(item.id, true)} />
+                        <BsTrash role="button" onClick={() => toggleDeleteMode(item.id, true)} />
                         {children}
                     </>
                 )}

--- a/frontend/src/views/instructors/courses/components/ItemTitle.tsx
+++ b/frontend/src/views/instructors/courses/components/ItemTitle.tsx
@@ -1,18 +1,28 @@
 import { useLayoutEffect, useRef, useState } from 'react';
 import { Col } from 'react-bootstrap';
-import { Module, ModuleItemProps } from '../types';
+import { Lecture, Module, ModuleItemProps } from '../types';
 
-type ItemTitleProps = Pick<ModuleItemProps, 'index' | 'editMode' | 'onToggleEditMode'> & {
-    item: Module;
-    onUpdateItem: ModuleItemProps['onUpdateModule'];
+type ItemTitleProps<T extends Module | Lecture> = Pick<
+    ModuleItemProps,
+    'index' | 'isEditing' | 'toggleEditMode' | 'onUpdateItem'
+> & {
+    item: T;
+    setItems: React.Dispatch<React.SetStateAction<T[]>>;
 };
 
-const ItemTitle: React.FC<ItemTitleProps> = ({ item, index, editMode, onToggleEditMode, onUpdateItem }) => {
+const ItemTitle = <T extends Module | Lecture>({
+    item,
+    index,
+    isEditing,
+    toggleEditMode,
+    onUpdateItem,
+    setItems,
+}: ItemTitleProps<T>) => {
     const inputRef = useRef<HTMLInputElement>(null);
     const [titleValue, setTitleValue] = useState('');
 
     useLayoutEffect(() => {
-        if (editMode && inputRef.current) {
+        if (isEditing && inputRef.current) {
             const newValue = item.title;
             setTitleValue(newValue);
             requestAnimationFrame(() => {
@@ -20,18 +30,18 @@ const ItemTitle: React.FC<ItemTitleProps> = ({ item, index, editMode, onToggleEd
                 inputRef.current?.select();
             });
         }
-    }, [editMode]);
+    }, [isEditing]);
 
     const handleKeydown = (e: React.KeyboardEvent<HTMLInputElement>) => {
         if (e.key === 'Enter') {
-            onUpdateItem({ ...item, title: titleValue });
-            onToggleEditMode(item.id, false);
+            onUpdateItem({ ...item, title: titleValue }, setItems);
+            toggleEditMode(item.id, false);
         }
     };
     return (
         <>
             <Col className="d-flex align-items-center px-1 flex-grow-1">
-                {editMode ? (
+                {isEditing ? (
                     <>
                         <span className="me-1">{index + 1}.</span>
                         <input
@@ -42,13 +52,13 @@ const ItemTitle: React.FC<ItemTitleProps> = ({ item, index, editMode, onToggleEd
                             onChange={(e) => setTitleValue(e.target.value)}
                             onKeyDown={handleKeydown}
                             onBlur={() => {
-                                onUpdateItem({ ...item, title: titleValue });
-                                onToggleEditMode(item.id, false);
+                                onUpdateItem({ ...item, title: titleValue }, setItems);
+                                toggleEditMode(item.id, false);
                             }}
                         />
                     </>
                 ) : (
-                    <span onDoubleClick={() => onToggleEditMode(item.id, true)}>{`${index + 1}. ${item.title}`}</span>
+                    <span onDoubleClick={() => toggleEditMode(item.id, true)}>{`${index + 1}. ${item.title}`}</span>
                 )}
             </Col>
         </>

--- a/frontend/src/views/instructors/courses/components/ItemTitle.tsx
+++ b/frontend/src/views/instructors/courses/components/ItemTitle.tsx
@@ -1,18 +1,11 @@
 import { useLayoutEffect, useRef, useState } from 'react';
 import { Col } from 'react-bootstrap';
+import { Module, ModuleItemProps } from '../types';
 
-interface Item {
-    id: string;
-    title: string;
-}
-
-interface ItemTitleProps {
-    item: Item;
-    index: number;
-    editMode: boolean;
-    onToggleEditMode: (moduleId: string, editMode: boolean) => void;
-    onUpdateItem: (updateModule: Item) => void;
-}
+type ItemTitleProps = Pick<ModuleItemProps, 'index' | 'editMode' | 'onToggleEditMode'> & {
+    item: Module;
+    onUpdateItem: ModuleItemProps['onUpdateModule'];
+};
 
 const ItemTitle: React.FC<ItemTitleProps> = ({ item, index, editMode, onToggleEditMode, onUpdateItem }) => {
     const inputRef = useRef<HTMLInputElement>(null);

--- a/frontend/src/views/instructors/courses/components/ItemTitle.tsx
+++ b/frontend/src/views/instructors/courses/components/ItemTitle.tsx
@@ -1,0 +1,65 @@
+import { useLayoutEffect, useRef, useState } from 'react';
+import { Col } from 'react-bootstrap';
+
+interface Item {
+    id: string;
+    title: string;
+}
+
+interface ItemTitleProps {
+    item: Item;
+    index: number;
+    editMode: boolean;
+    onToggleEditMode: (moduleId: string, editMode: boolean) => void;
+    onUpdateItem: (updateModule: Item) => void;
+}
+
+const ItemTitle: React.FC<ItemTitleProps> = ({ item, index, editMode, onToggleEditMode, onUpdateItem }) => {
+    const inputRef = useRef<HTMLInputElement>(null);
+    const [titleValue, setTitleValue] = useState('');
+
+    useLayoutEffect(() => {
+        if (editMode && inputRef.current) {
+            const newValue = item.title;
+            setTitleValue(newValue);
+            requestAnimationFrame(() => {
+                inputRef.current?.focus();
+                inputRef.current?.select();
+            });
+        }
+    }, [editMode]);
+
+    const handleKeydown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === 'Enter') {
+            onUpdateItem({ ...item, title: titleValue });
+            onToggleEditMode(item.id, false);
+        }
+    };
+    return (
+        <>
+            <Col className="d-flex align-items-center px-1 flex-grow-1">
+                {editMode ? (
+                    <>
+                        <span className="me-1">{index + 1}.</span>
+                        <input
+                            type="text"
+                            className="w-100 __module-item-input"
+                            ref={inputRef}
+                            value={titleValue}
+                            onChange={(e) => setTitleValue(e.target.value)}
+                            onKeyDown={handleKeydown}
+                            onBlur={() => {
+                                onUpdateItem({ ...item, title: titleValue });
+                                onToggleEditMode(item.id, false);
+                            }}
+                        />
+                    </>
+                ) : (
+                    <span onDoubleClick={() => onToggleEditMode(item.id, true)}>{`${index + 1}. ${item.title}`}</span>
+                )}
+            </Col>
+        </>
+    );
+};
+
+export default ItemTitle;

--- a/frontend/src/views/instructors/courses/createCourse/CourseDetails.tsx
+++ b/frontend/src/views/instructors/courses/createCourse/CourseDetails.tsx
@@ -2,7 +2,8 @@ import { BsPlusCircle } from 'react-icons/bs';
 import { FormControl, FormLabel, Button, Card, Container } from 'react-bootstrap';
 import { useTranslation } from 'react-i18next';
 import ModuleItem from './ModuleItem';
-import { CreateCourseContext, Module } from './context/CreateCourseContext';
+import { CreateCourseContext } from './context/CreateCourseContext';
+import { Module, ModeMap } from '../types';
 import useSafeContext from '@/hooks/useSafeContext';
 import DraggableZone from '@/components/draggable/DraggableZone';
 import { Item } from '@/components/draggable/types';
@@ -20,8 +21,9 @@ const CourseDetails = () => {
         setCourseTitle,
         handleOnBlurTitle,
     } = useSafeContext(CreateCourseContext);
-    const [editModeMap, setEditModeMap] = useState<Record<string, boolean>>({});
-    const [deleteModeMap, setDeleteModeMap] = useState<Record<string, boolean>>({});
+    const [editModeMap, setEditModeMap] = useState<ModeMap>({});
+    const [deleteModeMap, setDeleteModeMap] = useState<ModeMap>({});
+    const [dropDownModeMap, setDropDownModeMap] = useState<ModeMap>({});
 
     const toggleEditMode = (moduleId: string, editMode: boolean) => {
         setEditModeMap((prev) => ({ ...prev, [moduleId]: editMode }));
@@ -29,6 +31,10 @@ const CourseDetails = () => {
 
     const toggleDeleteMode = (moduleId: string, editMode: boolean) => {
         setDeleteModeMap((prev) => ({ ...prev, [moduleId]: editMode }));
+    };
+
+    const toggleDropDownMode = (moduleId: string, editMode: boolean) => {
+        setDropDownModeMap((prev) => ({ ...prev, [moduleId]: editMode }));
     };
 
     const handleAddModule = () => {
@@ -91,6 +97,8 @@ const CourseDetails = () => {
                                         deleteMode={deleteModeMap[mod.id] || false}
                                         onToggleDeleteMode={toggleDeleteMode}
                                         onDelete={handleDeleteButton}
+                                        dropDownMode={dropDownModeMap[mod.id] || false}
+                                        onToggleDropDownMode={toggleDropDownMode}
                                     />
                                 ))
                             ) : (

--- a/frontend/src/views/instructors/courses/createCourse/CourseDetails.tsx
+++ b/frontend/src/views/instructors/courses/createCourse/CourseDetails.tsx
@@ -15,11 +15,12 @@ const CourseDetails = () => {
         modules,
         setModules,
         addModule,
-        updateModule,
-        handleDeleteButton,
+        updateItem,
+        deleteItem,
         courseTitle,
         setCourseTitle,
-        handleOnBlurTitle,
+        changeCourseTitle,
+        idGenerator,
     } = useSafeContext(CreateCourseContext);
     const [editModeMap, setEditModeMap] = useState<ModeMap>({});
     const [deleteModeMap, setDeleteModeMap] = useState<ModeMap>({});
@@ -55,7 +56,7 @@ const CourseDetails = () => {
     const handleKeydown = (e: React.KeyboardEvent<HTMLInputElement>) => {
         if (e.key === 'Enter') {
             e.preventDefault();
-            handleOnBlurTitle(courseTitle);
+            changeCourseTitle(courseTitle);
             inputRef.current?.blur();
         }
     };
@@ -69,7 +70,7 @@ const CourseDetails = () => {
                     value={courseTitle}
                     ref={inputRef}
                     onChange={(e) => setCourseTitle(e.target.value)}
-                    onBlur={(e) => handleOnBlurTitle(e.target.value)}
+                    onBlur={(e) => changeCourseTitle(e.target.value)}
                     onKeyDown={handleKeydown}
                 />
             </div>
@@ -84,21 +85,25 @@ const CourseDetails = () => {
                 </div>
                 <Card className="p-0">
                     <DraggableZone items={modules} updateItems={(items: Item[]) => setModules(items as Module[])}>
-                        <Container fluid>
+                        <Container fluid className="p-0">
                             {modules.length > 0 ? (
                                 modules.map((mod, index) => (
                                     <ModuleItem
                                         module={mod}
                                         index={index}
                                         key={mod.id}
-                                        editMode={editModeMap[mod.id] || false}
-                                        onToggleEditMode={toggleEditMode}
-                                        onUpdateModule={updateModule}
-                                        deleteMode={deleteModeMap[mod.id] || false}
-                                        onToggleDeleteMode={toggleDeleteMode}
-                                        onDelete={handleDeleteButton}
-                                        dropDownMode={dropDownModeMap[mod.id] || false}
-                                        onToggleDropDownMode={toggleDropDownMode}
+                                        isEditing={editModeMap[mod.id] || false}
+                                        toggleEditMode={toggleEditMode}
+                                        onUpdateItem={updateItem}
+                                        isDeleting={deleteModeMap[mod.id] || false}
+                                        toggleDeleteMode={toggleDeleteMode}
+                                        onDeleteItem={deleteItem}
+                                        isDropDownOpen={dropDownModeMap[mod.id] || false}
+                                        toggleDropDownMode={toggleDropDownMode}
+                                        idGenerator={idGenerator}
+                                        editModeMap={editModeMap}
+                                        deleteModeMap={deleteModeMap}
+                                        setModules={setModules}
                                     />
                                 ))
                             ) : (

--- a/frontend/src/views/instructors/courses/createCourse/LectureItem.tsx
+++ b/frontend/src/views/instructors/courses/createCourse/LectureItem.tsx
@@ -1,0 +1,48 @@
+import DraggableItem from '@/components/draggable/DraggableItem';
+import { ModuleItemProps, Lecture } from '../types';
+import ItemTitle from '../components/ItemTitle';
+import ItemActionButtons from '../components/ItemActionButtons';
+
+type LectureItemProps = Pick<
+    ModuleItemProps,
+    'index' | 'isEditing' | 'toggleEditMode' | 'isDeleting' | 'toggleDeleteMode' | 'onUpdateItem' | 'onDeleteItem'
+> & {
+    lecture: Lecture;
+    setItems: React.Dispatch<React.SetStateAction<Lecture[]>>;
+};
+
+const LectureItem: React.FC<LectureItemProps> = ({
+    lecture,
+    index,
+    isEditing,
+    isDeleting,
+    toggleEditMode,
+    toggleDeleteMode,
+    onUpdateItem,
+    setItems,
+    onDeleteItem,
+}) => {
+    return (
+        <>
+            <DraggableItem item={lecture} itemClass={'__draggable-item-lightGrey'}>
+                <ItemTitle<Lecture>
+                    item={lecture}
+                    index={index}
+                    isEditing={isEditing}
+                    toggleEditMode={toggleEditMode}
+                    onUpdateItem={onUpdateItem}
+                    setItems={setItems}
+                />
+                <ItemActionButtons<Lecture>
+                    item={lecture}
+                    isDeleting={isDeleting}
+                    toggleDeleteMode={toggleDeleteMode}
+                    onDeleteItem={onDeleteItem}
+                    setItems={setItems}
+                ></ItemActionButtons>
+            </DraggableItem>
+        </>
+    );
+};
+
+export default LectureItem;

--- a/frontend/src/views/instructors/courses/createCourse/ModuleItem.tsx
+++ b/frontend/src/views/instructors/courses/createCourse/ModuleItem.tsx
@@ -1,7 +1,7 @@
 import DraggableItem from '@/components/draggable/DraggableItem';
 import ItemTitle from '../components/ItemTitle';
 import ItemActionButtons from '../components/ItemActionButtons';
-import { BsChevronDown, BsPlus, BsPlusCircle } from 'react-icons/bs';
+import { BsDash, BsPlus, BsPlusCircle } from 'react-icons/bs';
 import { ModuleItemProps, Lecture, Module } from '../types';
 import DraggableZone from '@/components/draggable/DraggableZone';
 import { Button, Col, Row } from 'react-bootstrap';
@@ -67,7 +67,7 @@ const ModuleItem: React.FC<ModuleItemProps> = ({
                     setItems={setModules}
                 >
                     {isDropDownOpen ? (
-                        <BsChevronDown role="button" onClick={() => toggleDropDownMode(module.id, false)} />
+                        <BsDash role="button" onClick={() => toggleDropDownMode(module.id, false)} />
                     ) : (
                         <BsPlus role="button" onClick={() => toggleDropDownMode(module.id, true)} />
                     )}

--- a/frontend/src/views/instructors/courses/createCourse/ModuleItem.tsx
+++ b/frontend/src/views/instructors/courses/createCourse/ModuleItem.tsx
@@ -1,23 +1,10 @@
 import DraggableItem from '@/components/draggable/DraggableItem';
 import ItemTitle from '../components/ItemTitle';
 import ItemActionButtons from '../components/ItemActionButtons';
-import { BsPlus } from 'react-icons/bs';
-
-interface Module {
-    id: string;
-    title: string;
-}
-
-interface ModuleItemProps {
-    module: Module;
-    index: number;
-    editMode: boolean;
-    onToggleEditMode: (moduleId: string, editMode: boolean) => void;
-    onUpdateModule: (updateModule: Module) => void;
-    deleteMode: boolean;
-    onToggleDeleteMode: (moduleId: string, editMode: boolean) => void;
-    onDelete: (id: string) => void;
-}
+import { BsChevronDown, BsPlus } from 'react-icons/bs';
+import { ModuleItemProps } from '../types';
+//import DraggableZone from '@/components/draggable/DraggableZone';
+import { Container } from 'react-bootstrap';
 
 const ModuleItem: React.FC<ModuleItemProps> = ({
     module,
@@ -28,25 +15,34 @@ const ModuleItem: React.FC<ModuleItemProps> = ({
     deleteMode,
     onToggleDeleteMode,
     onDelete,
+    dropDownMode,
+    onToggleDropDownMode,
 }) => {
     return (
-        <DraggableItem item={module}>
-            <ItemTitle
-                item={module}
-                index={index}
-                editMode={editMode}
-                onToggleEditMode={onToggleEditMode}
-                onUpdateItem={onUpdateModule}
-            />
-            <ItemActionButtons
-                item={module}
-                deleteMode={deleteMode}
-                onToggleDeleteMode={onToggleDeleteMode}
-                onDelete={onDelete}
-            >
-                <BsPlus role="button" />
-            </ItemActionButtons>
-        </DraggableItem>
+        <>
+            <DraggableItem item={module}>
+                <ItemTitle
+                    item={module}
+                    index={index}
+                    editMode={editMode}
+                    onToggleEditMode={onToggleEditMode}
+                    onUpdateItem={onUpdateModule}
+                />
+                <ItemActionButtons
+                    item={module}
+                    deleteMode={deleteMode}
+                    onToggleDeleteMode={onToggleDeleteMode}
+                    onDelete={onDelete}
+                >
+                    {dropDownMode ? (
+                        <BsChevronDown role="button" onClick={() => onToggleDropDownMode(module.id, false)} />
+                    ) : (
+                        <BsPlus role="button" onClick={() => onToggleDropDownMode(module.id, true)} />
+                    )}
+                </ItemActionButtons>
+            </DraggableItem>
+            {dropDownMode && <Container>Hola</Container>}
+        </>
     );
 };
 

--- a/frontend/src/views/instructors/courses/createCourse/ModuleItem.tsx
+++ b/frontend/src/views/instructors/courses/createCourse/ModuleItem.tsx
@@ -1,8 +1,7 @@
-import { Button, Col } from 'react-bootstrap';
-import { BsPencilSquare, BsPlus, BsTrash } from 'react-icons/bs';
 import DraggableItem from '@/components/draggable/DraggableItem';
-import { useLayoutEffect, useRef, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import ItemTitle from '../components/ItemTitle';
+import ItemActionButtons from '../components/ItemActionButtons';
+import { BsPlus } from 'react-icons/bs';
 
 interface Module {
     id: string;
@@ -30,79 +29,23 @@ const ModuleItem: React.FC<ModuleItemProps> = ({
     onToggleDeleteMode,
     onDelete,
 }) => {
-    const inputRef = useRef<HTMLInputElement>(null);
-    const [titleValue, setTitleValue] = useState('');
-    const { t } = useTranslation();
-
-    useLayoutEffect(() => {
-        if (editMode && inputRef.current) {
-            const newValue = module.title;
-            setTitleValue(newValue);
-            requestAnimationFrame(() => {
-                inputRef.current?.focus();
-                inputRef.current?.select();
-            });
-        }
-    }, [editMode]);
-
-    const handleKeydown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-        if (e.key === 'Enter') {
-            onUpdateModule({ ...module, title: titleValue });
-            onToggleEditMode(module.id, false);
-        }
-    };
-
     return (
         <DraggableItem item={module}>
-            <Col className="d-flex align-items-center px-1 flex-grow-1">
-                {editMode ? (
-                    <>
-                        <span className="me-1">{index + 1}.</span>
-                        <input
-                            type="text"
-                            className="w-100 __module-item-input"
-                            ref={inputRef}
-                            value={titleValue}
-                            onChange={(e) => setTitleValue(e.target.value)}
-                            onKeyDown={handleKeydown}
-                            onBlur={() => {
-                                onUpdateModule({ ...module, title: titleValue });
-                                onToggleEditMode(module.id, false);
-                            }}
-                        />
-                    </>
-                ) : (
-                    <span
-                        onDoubleClick={() => onToggleEditMode(module.id, true)}
-                    >{`${index + 1}. ${module.title}`}</span>
-                )}
-            </Col>
-
-            <Col xs="auto" className="d-flex gap-3 px-1 ">
-                {deleteMode ? (
-                    <>
-                        <div className="__module-item-deleteButton">
-                            <Button size="sm" variant="link" className="p-0 m-0" onClick={() => onDelete(module.id)}>
-                                {t('views.common.delete')}
-                            </Button>
-                        </div>
-                        <div
-                            className="__module-item-cancelButton"
-                            onClick={() => onToggleDeleteMode(module.id, false)}
-                        >
-                            <Button size="sm" variant="link" className="p-0 m-0">
-                                {t('views.common.cancel')}
-                            </Button>
-                        </div>
-                    </>
-                ) : (
-                    <>
-                        <BsPencilSquare role="button" />
-                        <BsTrash role="button" onClick={() => onToggleDeleteMode(module.id, true)} />
-                        <BsPlus role="button" />
-                    </>
-                )}
-            </Col>
+            <ItemTitle
+                item={module}
+                index={index}
+                editMode={editMode}
+                onToggleEditMode={onToggleEditMode}
+                onUpdateItem={onUpdateModule}
+            />
+            <ItemActionButtons
+                item={module}
+                deleteMode={deleteMode}
+                onToggleDeleteMode={onToggleDeleteMode}
+                onDelete={onDelete}
+            >
+                <BsPlus role="button" />
+            </ItemActionButtons>
         </DraggableItem>
     );
 };

--- a/frontend/src/views/instructors/courses/createCourse/ModuleItem.tsx
+++ b/frontend/src/views/instructors/courses/createCourse/ModuleItem.tsx
@@ -1,47 +1,114 @@
 import DraggableItem from '@/components/draggable/DraggableItem';
 import ItemTitle from '../components/ItemTitle';
 import ItemActionButtons from '../components/ItemActionButtons';
-import { BsChevronDown, BsPlus } from 'react-icons/bs';
-import { ModuleItemProps } from '../types';
-//import DraggableZone from '@/components/draggable/DraggableZone';
-import { Container } from 'react-bootstrap';
+import { BsChevronDown, BsPlus, BsPlusCircle } from 'react-icons/bs';
+import { ModuleItemProps, Lecture, Module } from '../types';
+import DraggableZone from '@/components/draggable/DraggableZone';
+import { Button, Col, Row } from 'react-bootstrap';
+import { useTranslation } from 'react-i18next';
+import { useEffect, useState } from 'react';
+import { Item } from '@/components/draggable/types';
+import LectureItem from './LectureItem';
 
 const ModuleItem: React.FC<ModuleItemProps> = ({
     module,
     index,
-    editMode,
-    onToggleEditMode,
-    onUpdateModule,
-    deleteMode,
-    onToggleDeleteMode,
-    onDelete,
-    dropDownMode,
-    onToggleDropDownMode,
+    isEditing,
+    toggleEditMode,
+    onUpdateItem,
+    isDeleting,
+    toggleDeleteMode,
+    onDeleteItem,
+    isDropDownOpen,
+    toggleDropDownMode,
+    idGenerator,
+    editModeMap,
+    deleteModeMap,
+    setModules,
 }) => {
+    const { t } = useTranslation();
+    const [lectures, setLectures] = useState<Lecture[]>(module.lectures);
+
+    const addLecture = () => {
+        const id = idGenerator();
+        const newLecture: Lecture = {
+            id,
+            title: 'Untitled',
+        };
+        setLectures((prev) => [...prev, newLecture]);
+        return newLecture;
+    };
+
+    const handleAddLecture = () => {
+        const newLecture = addLecture();
+        toggleEditMode(newLecture.id, true);
+    };
+
+    useEffect(() => {
+        onUpdateItem({ ...module, lectures }, setModules);
+    }, [lectures]);
+
     return (
         <>
-            <DraggableItem item={module}>
-                <ItemTitle
+            <DraggableItem item={module} itemClass={'__draggable-item-darkGrey'}>
+                <ItemTitle<Module>
                     item={module}
                     index={index}
-                    editMode={editMode}
-                    onToggleEditMode={onToggleEditMode}
-                    onUpdateItem={onUpdateModule}
+                    isEditing={isEditing}
+                    toggleEditMode={toggleEditMode}
+                    onUpdateItem={onUpdateItem}
+                    setItems={setModules}
                 />
-                <ItemActionButtons
+                <ItemActionButtons<Module>
                     item={module}
-                    deleteMode={deleteMode}
-                    onToggleDeleteMode={onToggleDeleteMode}
-                    onDelete={onDelete}
+                    isDeleting={isDeleting}
+                    toggleDeleteMode={toggleDeleteMode}
+                    onDeleteItem={onDeleteItem}
+                    setItems={setModules}
                 >
-                    {dropDownMode ? (
-                        <BsChevronDown role="button" onClick={() => onToggleDropDownMode(module.id, false)} />
+                    {isDropDownOpen ? (
+                        <BsChevronDown role="button" onClick={() => toggleDropDownMode(module.id, false)} />
                     ) : (
-                        <BsPlus role="button" onClick={() => onToggleDropDownMode(module.id, true)} />
+                        <BsPlus role="button" onClick={() => toggleDropDownMode(module.id, true)} />
                     )}
                 </ItemActionButtons>
             </DraggableItem>
-            {dropDownMode && <Container>Hola</Container>}
+            {isDropDownOpen && (
+                <div className="ms-5">
+                    <DraggableZone items={lectures} updateItems={(items: Item[]) => setLectures(items as Lecture[])}>
+                        {lectures.length > 0 ? (
+                            lectures.map((lect, index) => (
+                                <LectureItem
+                                    key={lect.id}
+                                    lecture={lect}
+                                    index={index}
+                                    isEditing={editModeMap[lect.id] || false}
+                                    toggleEditMode={toggleEditMode}
+                                    isDeleting={deleteModeMap[lect.id] || false}
+                                    toggleDeleteMode={toggleDeleteMode}
+                                    onDeleteItem={onDeleteItem}
+                                    onUpdateItem={onUpdateItem}
+                                    setItems={setLectures}
+                                />
+                            ))
+                        ) : (
+                            <p>{t('views.instructors.courses.createCourse.noLectures')}</p>
+                        )}
+                    </DraggableZone>
+                    <Row className="p-0">
+                        <Col>
+                            <Button
+                                size="sm"
+                                className="d-flex align-items-center gap-2 m-0"
+                                onClick={handleAddLecture}
+                            >
+                                <BsPlusCircle />
+                                {t('views.instructors.courses.createCourse.addLecture')}
+                            </Button>
+                        </Col>
+                    </Row>
+                </div>
+            )}
         </>
     );
 };

--- a/frontend/src/views/instructors/courses/createCourse/context/CreateCourseContext.tsx
+++ b/frontend/src/views/instructors/courses/createCourse/context/CreateCourseContext.tsx
@@ -1,26 +1,27 @@
 import React, { createContext, ReactNode, useState } from 'react';
-import { Module } from '../../types';
+import { Module, Lecture } from '../../types';
 
 type Props = {
     children: ReactNode;
 };
 
-type updateModuleFn = (updatedModule: Module) => void;
-
 type Setter<T> = React.Dispatch<React.SetStateAction<T>>;
+
+type updateItemFn = <T extends Module | Lecture>(updatedItem: T, setItems: Setter<T[]>) => void;
+type deleteItemFn = <T extends Module | Lecture>(id: string, setItems: Setter<T[]>) => void;
 
 type VoidStringFn = (t: string) => void;
 
 type ContextType = {
     courseTitle: string;
     setCourseTitle: Setter<string>;
-
     modules: Module[];
     setModules: Setter<Module[]>;
     addModule: () => Module;
-    updateModule: updateModuleFn;
-    handleDeleteButton: (id: string) => void;
-    handleOnBlurTitle: VoidStringFn;
+    updateItem: updateItemFn;
+    deleteItem: deleteItemFn;
+    changeCourseTitle: VoidStringFn;
+    idGenerator: () => string;
 };
 
 export const CreateCourseContext = createContext<ContextType | undefined>(undefined);
@@ -28,14 +29,14 @@ export const CreateCourseContext = createContext<ContextType | undefined>(undefi
 const CreateCourseContextBoundary = ({ children }: Props) => {
     const [courseTitle, setCourseTitle] = useState('');
 
-    const handleOnBlurTitle = (value: string) => {
+    const changeCourseTitle = (value: string) => {
         setCourseTitle(value !== '' ? value : 'Untitled');
     };
 
     const [modules, setModules] = useState<Module[]>([
-        { id: '1', title: 'REST principles 01' },
-        { id: '2', title: 'REST principles 02' },
-        { id: '3', title: 'REST principles 03' },
+        { id: '1', title: 'REST principles 01', lectures: [] },
+        { id: '2', title: 'REST principles 02', lectures: [] },
+        { id: '3', title: 'REST principles 03', lectures: [] },
     ]);
 
     //Provisional function
@@ -48,40 +49,42 @@ const CreateCourseContextBoundary = ({ children }: Props) => {
         const newModule: Module = {
             id,
             title: 'Untitled',
+            lectures: [],
         };
         setModules((prev) => [...prev, newModule]);
         return newModule;
     };
 
-    const updateModule: updateModuleFn = (updatedModule) => {
-        if (updatedModule.title === '') {
-            updatedModule.title = 'Untitled';
+    const updateItem: updateItemFn = (updatedItem, setItems) => {
+        if (updatedItem.title === '') {
+            updatedItem.title = 'Untitled';
         }
-        setModules((prev) => {
-            const updatedModules = [...prev];
-            const index = updatedModules.findIndex((m) => m.id === updatedModule.id);
+        setItems((prev) => {
+            const updatedItems = [...prev];
+            const index = updatedItems.findIndex((m) => m.id === updatedItem.id);
             if (index !== -1) {
-                updatedModules.splice(index, 1, updatedModule);
+                updatedItems.splice(index, 1, updatedItem);
             }
-            return updatedModules;
+            return updatedItems;
         });
     };
 
     //Delete module
 
-    const handleDeleteButton = (id: string) => {
-        setModules((prev) => prev.filter((m) => m.id !== id));
+    const deleteItem: deleteItemFn = (id, setItems) => {
+        setItems((prev) => prev.filter((m) => m.id !== id));
     };
 
     const data: ContextType = {
         modules,
         setModules,
         addModule,
-        updateModule,
-        handleDeleteButton,
+        updateItem,
+        deleteItem,
         courseTitle,
         setCourseTitle,
-        handleOnBlurTitle,
+        changeCourseTitle,
+        idGenerator,
     };
 
     return <CreateCourseContext.Provider value={data}>{children}</CreateCourseContext.Provider>;

--- a/frontend/src/views/instructors/courses/createCourse/context/CreateCourseContext.tsx
+++ b/frontend/src/views/instructors/courses/createCourse/context/CreateCourseContext.tsx
@@ -1,9 +1,5 @@
 import React, { createContext, ReactNode, useState } from 'react';
-
-export interface Module {
-    id: string;
-    title: string;
-}
+import { Module } from '../../types';
 
 type Props = {
     children: ReactNode;

--- a/frontend/src/views/instructors/courses/types.ts
+++ b/frontend/src/views/instructors/courses/types.ts
@@ -1,0 +1,21 @@
+export type Module = {
+    id: string;
+    title: string;
+};
+
+type Toggle = (moduleId: string, editMode: boolean) => void;
+
+export type ModuleItemProps = {
+    module: Module;
+    index: number;
+    editMode: boolean;
+    onToggleEditMode: Toggle;
+    onUpdateModule: (updateModule: Module) => void;
+    deleteMode: boolean;
+    onToggleDeleteMode: Toggle;
+    onDelete: (id: string) => void;
+    dropDownMode: boolean;
+    onToggleDropDownMode: Toggle;
+};
+
+export type ModeMap = Record<string, boolean>;

--- a/frontend/src/views/instructors/courses/types.ts
+++ b/frontend/src/views/instructors/courses/types.ts
@@ -1,21 +1,34 @@
-export type Module = {
+export type Lecture = {
     id: string;
     title: string;
 };
+
+export type Module = {
+    id: string;
+    title: string;
+    lectures: Lecture[];
+};
+
+export type ModeMap = Record<string, boolean>;
 
 type Toggle = (moduleId: string, editMode: boolean) => void;
 
 export type ModuleItemProps = {
     module: Module;
     index: number;
-    editMode: boolean;
-    onToggleEditMode: Toggle;
-    onUpdateModule: (updateModule: Module) => void;
-    deleteMode: boolean;
-    onToggleDeleteMode: Toggle;
-    onDelete: (id: string) => void;
-    dropDownMode: boolean;
-    onToggleDropDownMode: Toggle;
+    isEditing: boolean;
+    toggleEditMode: Toggle;
+    onUpdateItem: <T extends Module | Lecture>(
+        updatedItem: T,
+        setItems: React.Dispatch<React.SetStateAction<T[]>>,
+    ) => void;
+    isDeleting: boolean;
+    toggleDeleteMode: Toggle;
+    onDeleteItem: <T extends Module | Lecture>(id: string, setItems: React.Dispatch<React.SetStateAction<T[]>>) => void;
+    isDropDownOpen: boolean;
+    toggleDropDownMode: Toggle;
+    idGenerator: () => string;
+    editModeMap: ModeMap;
+    deleteModeMap: ModeMap;
+    setModules: React.Dispatch<React.SetStateAction<Module[]>>;
 };
-
-export type ModeMap = Record<string, boolean>;


### PR DESCRIPTION
- Show the “Add Lecture” button when a module is expanded.
- Display a default message when the module has no lectures.
- When clicking “Add Lecture”, a new draggable item should be added as a “child” of the current module. It should always be added at the end.
- Replicate the experience from CMS1-4, CMS1-5, and CMS1-6 for lectures.