### PR TITLE
Complete scope for CMS1-10

### DIFF
--- a/frontend/src/views/instructors/courses/components/ItemActionButtons.tsx
+++ b/frontend/src/views/instructors/courses/components/ItemActionButtons.tsx
@@ -22,8 +22,13 @@ const ItemActionButtons = <T extends Module | Lecture>({
                                 {t('views.common.delete')}
                             </Button>
                         </div>
-                        <div className="__module-item-cancelButton" onClick={() => toggleDeleteMode(false)}>
-                            <Button size="sm" variant="link" className="p-0 m-0">
+                        <div className="__module-item-cancelButton">
+                            <Button
+                                size="sm"
+                                variant="link"
+                                className="p-0 m-0"
+                                onClick={() => toggleDeleteMode(false)}
+                            >
                                 {t('views.common.cancel')}
                             </Button>
                         </div>

--- a/frontend/src/views/instructors/courses/createCourse/CourseDetails.tsx
+++ b/frontend/src/views/instructors/courses/createCourse/CourseDetails.tsx
@@ -70,7 +70,7 @@ const CourseDetails = () => {
             </div>
 
             <section>
-                <div className="d-flex flex-row justify-content-between">
+                <div className="d-flex flex-row justify-content-between border-bottom mb-3 pb-2">
                     <h3>{t('views.instructors.courses.createCourse.modules')}</h3>
                     <Button size="sm" className="d-flex align-items-center gap-2" onClick={handleAddModule}>
                         <BsPlusCircle />

--- a/frontend/src/views/instructors/courses/createCourse/LectureDetails.tsx
+++ b/frontend/src/views/instructors/courses/createCourse/LectureDetails.tsx
@@ -14,7 +14,7 @@ const LectureDetails = () => {
             </div>
 
             <section>
-                <div className="d-flex flex-row justify-content-between">
+                <div className="d-flex flex-row justify-content-between border-bottom mb-3 pb-2">
                     <h3>{t('views.common.content')}</h3>
                 </div>
             </section>

--- a/frontend/src/views/instructors/courses/createCourse/ModuleDetails.tsx
+++ b/frontend/src/views/instructors/courses/createCourse/ModuleDetails.tsx
@@ -41,10 +41,19 @@ const ModuleDetails = () => {
         }
     }, [lectures]);
 
+    useEffect(() => {
+        setModuleTitle(module?.title ?? '');
+    }, [module]);
+
+    const handleUpdateTitle = () => {
+        module && updateItem({ ...module, title: moduleTitle !== '' ? moduleTitle : 'Untitled' }, setModules);
+    };
+
     const handleKeydown = (e: React.KeyboardEvent<HTMLInputElement>) => {
         if (e.key === 'Enter') {
             e.preventDefault();
-            module && updateItem({ ...module, title: moduleTitle }, setModules);
+            handleUpdateTitle();
+            (e.target as HTMLInputElement).blur();
         }
     };
 
@@ -56,9 +65,7 @@ const ModuleDetails = () => {
                     type="text"
                     value={moduleTitle}
                     onChange={(e) => setModuleTitle(e.target.value)}
-                    onBlur={() => {
-                        module && updateItem({ ...module, title: moduleTitle }, setModules);
-                    }}
+                    onBlur={handleUpdateTitle}
                     onKeyDown={handleKeydown}
                 />
             </div>

--- a/frontend/src/views/instructors/courses/createCourse/ModuleDetails.tsx
+++ b/frontend/src/views/instructors/courses/createCourse/ModuleDetails.tsx
@@ -1,27 +1,96 @@
 import useSafeContext from '@/hooks/useSafeContext';
-import { Button, FormControl, FormLabel } from 'react-bootstrap';
+import { Button, Card, FormControl, FormLabel } from 'react-bootstrap';
 import { useTranslation } from 'react-i18next';
 import { BsPlusCircle } from 'react-icons/bs';
 import { CreateCourseContext } from './context/CreateCourseContext';
+import DraggableZone from '@/components/draggable/DraggableZone';
+import LectureItem from './LectureItem';
+import { Lecture } from '../types';
+import { Item } from '@/components/draggable/types';
+import { useEffect, useState } from 'react';
 
 const ModuleDetails = () => {
     const { t } = useTranslation();
-    const { setEditingViewItem } = useSafeContext(CreateCourseContext);
+    const { modules, setModules, updateItem, deleteItem, idGenerator, editingViewItem, setEditingViewItem } =
+        useSafeContext(CreateCourseContext);
+
+    const module = editingViewItem?.type === 'module' ? modules.find((m) => m.id === editingViewItem.id) : undefined;
+    const [moduleTitle, setModuleTitle] = useState(module?.title ?? '');
+
+    const [lectures, setLectures] = useState<Lecture[]>(module?.lectures ?? []);
+    const [newLectureId, setNewLectureId] = useState<string | null>(null);
+
+    const addLecture = () => {
+        const id = idGenerator();
+        const newLecture: Lecture = {
+            id,
+            title: 'Untitled',
+        };
+        setLectures((prev) => [...prev, newLecture]);
+        return newLecture;
+    };
+
+    const handleAddLecture = () => {
+        const newLecture = addLecture();
+        setNewLectureId(newLecture.id);
+    };
+
+    useEffect(() => {
+        if (module) {
+            updateItem({ ...module, lectures }, setModules);
+        }
+    }, [lectures]);
+
+    const handleKeydown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            module && updateItem({ ...module, title: moduleTitle }, setModules);
+        }
+    };
+
     return (
         <section className="p-0">
             <div>
                 <FormLabel>{t('views.instructors.courses.createCourse.title')}</FormLabel>
-                <FormControl type="text" value={''} />
+                <FormControl
+                    type="text"
+                    value={moduleTitle}
+                    onChange={(e) => setModuleTitle(e.target.value)}
+                    onBlur={() => {
+                        module && updateItem({ ...module, title: moduleTitle }, setModules);
+                    }}
+                    onKeyDown={handleKeydown}
+                />
             </div>
 
             <section>
-                <div className="d-flex flex-row justify-content-between">
-                    <h3>{t('views.instructors.courses.createCourse.modules')}</h3>
-                    <Button size="sm" className="d-flex align-items-center gap-2">
+                <div className="d-flex flex-row justify-content-between border-bottom mb-3 pb-2">
+                    <h3>{t('views.instructors.courses.createCourse.lectures')}</h3>
+                    <Button size="sm" className="d-flex align-items-center gap-2" onClick={handleAddLecture}>
                         <BsPlusCircle />
                         {t('views.instructors.courses.createCourse.addLecture')}
                     </Button>
                 </div>
+                <Card className="p-0">
+                    <DraggableZone items={lectures} updateItems={(items: Item[]) => setLectures(items as Lecture[])}>
+                        {lectures.length > 0 ? (
+                            lectures.map((lect, index) => (
+                                <LectureItem
+                                    key={lect.id}
+                                    lecture={lect}
+                                    index={index}
+                                    onDeleteItem={deleteItem}
+                                    onUpdateItem={updateItem}
+                                    setLectures={setLectures}
+                                    isNewLecture={lect.id === newLectureId}
+                                    setEditingViewItem={setEditingViewItem}
+                                />
+                            ))
+                        ) : (
+                            <p>{t('views.instructors.courses.createCourse.noLectures')}</p>
+                        )}
+                    </DraggableZone>
+                </Card>
             </section>
             <div className="d-flex justify-content-end mt-3">
                 <Button


### PR DESCRIPTION
Edit Module Page
This page is rendered when clicking the edit icon of a module.
It allows setting the module title —  CMS1-6 logic is applied here.
Enable viewing and adding lectures to the module, using a draggable experience.
Replicate the behavior of CMS1-3, CMS1-4, and CMS1-5 on this page too.