### PR TITLE
CMS1-16

### DIFF
--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -30,6 +30,11 @@
                         "attachments": "Attachments",
                         "attachmentsText": "Add up to 3 additional downloadable attachments to the lecture.",
                         "uploadAttachment": "Upload attachment",
+                        "attachmentErrors": {
+                            "invalidType": "Tipo de archivo no válido",
+                            "fileTooLarge": "El archivo excede el tamaño máximo permitido (1mb)",
+                            "tooManyFiles": "Se ha excedido el máximo de archivos adjuntos permitidos (3)"
+                        },
                         "addFromLibrary": "Add from library",
                         "lectureTypeModal": "If you continue the current lecture's data will be deleted."
                     }

--- a/frontend/public/locales/es/translation.json
+++ b/frontend/public/locales/es/translation.json
@@ -30,6 +30,11 @@
                         "attachments": "Adjuntos",
                         "attachmentsText": "Añade hasta 3 archivos adjuntos descargables adicionales a la clase.",
                         "uploadAttachment": "Subir adjunto",
+                        "attachmentErrors": {
+                            "invalidType": "Invalid file type",
+                            "fileTooLarge": "The file exceeds the maximum allowed size (1MB)",
+                            "tooManyFiles": "The maximum number of allowed attachments (3) has been exceeded"
+                        },
                         "addFromLibrary": "Agregar desde la biblioteca",
                         "lectureTypeModal": "Si continúas se eliminarán los datos de la clase actual."
                     }

--- a/frontend/src/hooks/useUploadAttachment.tsx
+++ b/frontend/src/hooks/useUploadAttachment.tsx
@@ -1,0 +1,67 @@
+import { useState, useCallback } from 'react';
+import { Resources } from '@/views/instructors/courses/types';
+
+type UseUploadAttachmentResult = {
+    progress: number;
+    data: Resources | null;
+    error: Error | null;
+    uploadFile: (file: File) => Promise<Resources>;
+    reset: () => void;
+};
+
+export const useUploadAttachment = (): UseUploadAttachmentResult => {
+    const [progress, setProgress] = useState(0);
+    const [data, setData] = useState<Resources | null>(null);
+    const [error, setError] = useState<Error | null>(null);
+
+    const reset = () => {
+        setProgress(0);
+        setData(null);
+        setError(null);
+    };
+
+    const uploadFile = useCallback(async (file: File): Promise<Resources> => {
+        reset();
+
+        const simulatedResponse: Resources = {
+            id: `attachment-${Date.now()}`,
+            title: file.name,
+            url: 'https://habitatbroward.org/wp-content/uploads/2020/01/10-Benefits-Showing-Why-Education-Is-Important-to-Our-Society.jpg',
+        };
+
+        return new Promise<Resources>((resolve, reject) => {
+            const isTooLarge = file.size > 1024 * 1024;
+            if (isTooLarge) {
+                const err = new Error('File exceeds maximum size of 1MB');
+                setError(err);
+                return reject(err);
+            }
+
+            let currentProgress = 0;
+            const totalDuration = 2000;
+            const intervalTime = 100;
+            const steps = totalDuration / intervalTime;
+            let currentStep = 0;
+
+            const interval = setInterval(() => {
+                currentStep++;
+                currentProgress = Math.min(1, currentStep / steps);
+                setProgress(currentProgress);
+                if (currentProgress === 1) {
+                    clearInterval(interval);
+                    setData(simulatedResponse);
+                    resolve(simulatedResponse);
+                }
+            }, intervalTime);
+        }).catch((err: unknown) => {
+            if (err instanceof Error) {
+                setError(err);
+            } else {
+                setError(new Error(`An unexpected error occurred: ${String(err)}`));
+            }
+            throw err;
+        });
+    }, []);
+
+    return { progress, data, error, uploadFile, reset };
+};

--- a/frontend/src/views/instructors/courses/components/ItemTitle.tsx
+++ b/frontend/src/views/instructors/courses/components/ItemTitle.tsx
@@ -1,8 +1,8 @@
 import { useLayoutEffect, useRef, useState } from 'react';
 import { Col } from 'react-bootstrap';
-import { Lecture, Module, ItemTitleProps } from '../types';
+import { Lecture, Module, Resources, ItemTitleProps } from '../types';
 
-const ItemTitle = <T extends Module | Lecture>({
+const ItemTitle = <T extends Module | Lecture | Resources>({
     item,
     index,
     isEditing,

--- a/frontend/src/views/instructors/courses/components/LectureAttachmentItem.tsx
+++ b/frontend/src/views/instructors/courses/components/LectureAttachmentItem.tsx
@@ -1,0 +1,23 @@
+import ItemTitle from './ItemTitle';
+import { Row } from 'react-bootstrap';
+import { ItemTitleProps, Resources } from '../types';
+import { useState } from 'react';
+
+type LectureAttachmentItemProps = Pick<ItemTitleProps<Resources>, 'item' | 'index' | 'onUpdateItem'>;
+
+const LectureAttachmentItem = ({ item, index, onUpdateItem }: LectureAttachmentItemProps) => {
+    const [isEditing, setIsEditing] = useState(false);
+    return (
+        <Row className="d-flex align-items-center px-2 py-2 text-dark my-2 g-0 __item-row">
+            <ItemTitle
+                item={item}
+                index={index}
+                isEditing={isEditing}
+                toggleEditMode={setIsEditing}
+                onUpdateItem={onUpdateItem}
+            />
+        </Row>
+    );
+};
+
+export default LectureAttachmentItem;

--- a/frontend/src/views/instructors/courses/components/LectureAttachmentSection.scss
+++ b/frontend/src/views/instructors/courses/components/LectureAttachmentSection.scss
@@ -1,0 +1,5 @@
+@use '@/assets/scss/style.scss' as *;
+
+.__item-row {
+    background-color: $gray-300;
+}

--- a/frontend/src/views/instructors/courses/components/LectureAttachmentSection.tsx
+++ b/frontend/src/views/instructors/courses/components/LectureAttachmentSection.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { Button, Col, Container, Placeholder, Row } from 'react-bootstrap';
 import { useTranslation } from 'react-i18next';
 import { BsPlusCircle } from 'react-icons/bs';
-import { Lecture, LectureAttachmentSectionProps } from '../types';
+import { Lecture, LectureAttachmentSectionProps, Resource } from '../types';
 import './LectureAttachmentSection.scss';
 import LectureAttachmentItem from './LectureAttachmentItem';
 
@@ -24,7 +24,7 @@ const acceptedTypes = [
 const maxFileSize = 1024 * 1024;
 const maxAttachments = 3;
 
-const LectureAttachmentSection = ({ lecture, module, updateLecture, onUpdateItem }: LectureAttachmentSectionProps) => {
+const LectureAttachmentSection = ({ lecture, module, updateLecture }: LectureAttachmentSectionProps) => {
     const { t } = useTranslation();
     const {
         progress,
@@ -33,7 +33,8 @@ const LectureAttachmentSection = ({ lecture, module, updateLecture, onUpdateItem
         uploadFile,
         reset: resetFileData,
     } = useUploadAttachment();
-    const [attachments, setAttachments] = useState<any[]>([]);
+    const attachments = lecture?.resources ?? [];
+
     const [fileValidationError, setFileValidationError] = useState<string | null>(null);
 
     const combinedUploadError = fileValidationError || uploadError?.message;
@@ -43,12 +44,6 @@ const LectureAttachmentSection = ({ lecture, module, updateLecture, onUpdateItem
     const openFilePicker = () => {
         fileInputRef.current?.click();
     };
-
-    useEffect(() => {
-        if (lecture?.resources) {
-            setAttachments(lecture.resources);
-        }
-    }, [lecture]);
 
     useEffect(() => {
         if (!uploadedFileData || !lecture || !module) return;
@@ -88,6 +83,12 @@ const LectureAttachmentSection = ({ lecture, module, updateLecture, onUpdateItem
         }
     };
 
+    const handleUpdateAttachment = (updatedItem: Resource) => {
+        if (!lecture) return;
+        const updatedResources = lecture.resources?.map((r) => (r.id === updatedItem.id ? updatedItem : r)) ?? [];
+        updateLecture({ ...lecture, resources: updatedResources });
+    };
+
     return (
         <section className="p-1 my-2">
             <div className="d-flex flex-row justify-content-between border-bottom mb-3 pb-2">
@@ -107,7 +108,7 @@ const LectureAttachmentSection = ({ lecture, module, updateLecture, onUpdateItem
                             key={at.id}
                             item={at}
                             index={index}
-                            onUpdateItem={(updatedItem) => onUpdateItem(updatedItem, setAttachments)}
+                            onUpdateItem={handleUpdateAttachment}
                         />
                     ))}
                 {progress > 0 && progress < 1 && (

--- a/frontend/src/views/instructors/courses/components/LectureAttachmentSection.tsx
+++ b/frontend/src/views/instructors/courses/components/LectureAttachmentSection.tsx
@@ -4,8 +4,8 @@ import { Button, Col, Container, Placeholder, Row } from 'react-bootstrap';
 import { useTranslation } from 'react-i18next';
 import { BsPlusCircle } from 'react-icons/bs';
 import { Lecture, LectureAttachmentSectionProps } from '../types';
-import ItemTitle from './ItemTitle';
 import './LectureAttachmentSection.scss';
+import LectureAttachmentItem from './LectureAttachmentItem';
 
 const acceptedTypes = [
     'application/pdf',
@@ -35,7 +35,6 @@ const LectureAttachmentSection = ({ lecture, module, updateLecture, onUpdateItem
     } = useUploadAttachment();
     const [attachments, setAttachments] = useState<any[]>([]);
     const [fileValidationError, setFileValidationError] = useState<string | null>(null);
-    const [isEditing, setIsEditing] = useState(false);
 
     const combinedUploadError = fileValidationError || uploadError?.message;
 
@@ -104,15 +103,12 @@ const LectureAttachmentSection = ({ lecture, module, updateLecture, onUpdateItem
             <Container>
                 {attachments.length > 0 &&
                     attachments.map((at, index) => (
-                        <Row key={at.id} className="d-flex align-items-center px-2 py-2 text-dark my-2 g-0 __item-row">
-                            <ItemTitle
-                                item={at}
-                                index={index}
-                                isEditing={isEditing}
-                                toggleEditMode={setIsEditing}
-                                onUpdateItem={(updatedItem) => onUpdateItem(updatedItem, setAttachments)}
-                            />
-                        </Row>
+                        <LectureAttachmentItem
+                            key={at.id}
+                            item={at}
+                            index={index}
+                            onUpdateItem={(updatedItem) => onUpdateItem(updatedItem, setAttachments)}
+                        />
                     ))}
                 {progress > 0 && progress < 1 && (
                     <Row className="px-2 py-2 my-2 g-0">

--- a/frontend/src/views/instructors/courses/components/LectureAttachmentSection.tsx
+++ b/frontend/src/views/instructors/courses/components/LectureAttachmentSection.tsx
@@ -1,0 +1,141 @@
+import { useUploadAttachment } from '@/hooks/useUploadAttachment';
+import React, { useEffect, useRef, useState } from 'react';
+import { Button, Col, Container, Placeholder, Row } from 'react-bootstrap';
+import { useTranslation } from 'react-i18next';
+import { BsPlusCircle } from 'react-icons/bs';
+import { Lecture, LectureAttachmentSectionProps } from '../types';
+import ItemTitle from './ItemTitle';
+import './LectureAttachmentSection.scss';
+
+const acceptedTypes = [
+    'application/pdf',
+    'application/msword',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    'application/vnd.ms-excel', // .xls
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    'application/vnd.ms-powerpoint', // .ppt
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    'text/csv',
+    'image/jpeg',
+    'image/jpg',
+    'image/png',
+];
+
+const maxFileSize = 1024 * 1024;
+const maxAttachments = 3;
+
+const LectureAttachmentSection = ({ lecture, module, updateLecture, onUpdateItem }: LectureAttachmentSectionProps) => {
+    const { t } = useTranslation();
+    const {
+        progress,
+        data: uploadedFileData,
+        error: uploadError,
+        uploadFile,
+        reset: resetFileData,
+    } = useUploadAttachment();
+    const [attachments, setAttachments] = useState<any[]>([]);
+    const [fileValidationError, setFileValidationError] = useState<string | null>(null);
+    const [isEditing, setIsEditing] = useState(false);
+
+    const combinedUploadError = fileValidationError || uploadError?.message;
+
+    const fileInputRef = useRef<HTMLInputElement>(null);
+
+    const openFilePicker = () => {
+        fileInputRef.current?.click();
+    };
+
+    useEffect(() => {
+        if (lecture?.resources) {
+            setAttachments(lecture.resources);
+        }
+    }, [lecture]);
+
+    useEffect(() => {
+        if (!uploadedFileData || !lecture || !module) return;
+        const attachmentData = uploadedFileData;
+        const updatedLecture: Lecture = {
+            ...lecture,
+            resources: [...(lecture.resources || []), attachmentData],
+        };
+        updateLecture(updatedLecture);
+        resetFileData();
+        fileInputRef.current && (fileInputRef.current.value = '');
+    }, [uploadedFileData, lecture, module]);
+
+    const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setFileValidationError(null);
+        const file = e.target.files?.[0];
+        if (file) {
+            if (!acceptedTypes.includes(file.type)) {
+                setFileValidationError(
+                    t('views.instructors.courses.createCourse.editLecture.attachmentErrors.invalidType'),
+                );
+                return;
+            }
+            if (file.size > maxFileSize) {
+                setFileValidationError(
+                    t('views.instructors.courses.createCourse.editLecture.attachmentErrors.fileTooLarge'),
+                );
+                return;
+            }
+            if (attachments.length >= maxAttachments) {
+                setFileValidationError(
+                    t('views.instructors.courses.createCourse.editLecture.attachmentErrors.tooManyFiles'),
+                );
+                return;
+            }
+            uploadFile(file);
+        }
+    };
+
+    return (
+        <section className="p-1 my-2">
+            <div className="d-flex flex-row justify-content-between border-bottom mb-3 pb-2">
+                <h3>{t('views.instructors.courses.createCourse.editLecture.attachments')}</h3>
+            </div>
+            <p className="text-black">{t('views.instructors.courses.createCourse.editLecture.attachmentsText')}</p>
+            <div className="d-flex flex-row gap-2">
+                <Button size="sm" className="d-flex align-items-center gap-2" onClick={openFilePicker}>
+                    <BsPlusCircle />
+                    {t('views.instructors.courses.createCourse.editLecture.uploadAttachment')}
+                </Button>
+            </div>
+            <Container>
+                {attachments.length > 0 &&
+                    attachments.map((at, index) => (
+                        <Row key={at.id} className="d-flex align-items-center px-2 py-2 text-dark my-2 g-0 __item-row">
+                            <ItemTitle
+                                item={at}
+                                index={index}
+                                isEditing={isEditing}
+                                toggleEditMode={setIsEditing}
+                                onUpdateItem={(updatedItem) => onUpdateItem(updatedItem, setAttachments)}
+                            />
+                        </Row>
+                    ))}
+                {progress > 0 && progress < 1 && (
+                    <Row className="px-2 py-2 my-2 g-0">
+                        <Placeholder as={Col} animation="glow">
+                            <Placeholder xs={12} size="lg" />
+                        </Placeholder>
+                    </Row>
+                )}
+                {combinedUploadError && (
+                    <Row className="px-2 py-2 text-danger my-2 g-0">
+                        <Col>{combinedUploadError}</Col>
+                    </Row>
+                )}
+            </Container>
+            <input
+                type="file"
+                accept=".pdf, .ppt, .pptx, .doc, .docx, .csv, .xls, .xlsx, .png, .jpeg, .jpg"
+                ref={fileInputRef}
+                onChange={handleFileChange}
+                style={{ display: 'none' }}
+            />
+        </section>
+    );
+};
+
+export default LectureAttachmentSection;

--- a/frontend/src/views/instructors/courses/createCourse/LectureDetails.tsx
+++ b/frontend/src/views/instructors/courses/createCourse/LectureDetails.tsx
@@ -2,10 +2,10 @@ import useSafeContext from '@/hooks/useSafeContext';
 import { Button, FormControl, FormLabel } from 'react-bootstrap';
 import { useTranslation } from 'react-i18next';
 import { CreateCourseContext } from './context/CreateCourseContext';
-import { BsPlusCircle } from 'react-icons/bs';
 import React, { useEffect, useState, useMemo } from 'react';
 import { Lecture } from '../types';
 import LectureContentSection from '../components/LectureContentSection';
+import LectureAttachmentSection from '../components/LectureAttachmentSection';
 
 const LectureDetails = () => {
     const { t } = useTranslation();
@@ -66,18 +66,12 @@ const LectureDetails = () => {
 
             <LectureContentSection lecture={lecture} module={module} updateLecture={updateLecture} />
 
-            <section className="p-1 my-2">
-                <div className="d-flex flex-row justify-content-between border-bottom mb-3 pb-2">
-                    <h3>{t('views.instructors.courses.createCourse.editLecture.attachments')}</h3>
-                </div>
-                <p className="text-black">{t('views.instructors.courses.createCourse.editLecture.attachmentsText')}</p>
-                <div className="d-flex flex-row gap-2">
-                    <Button size="sm" className="d-flex align-items-center gap-2">
-                        <BsPlusCircle />
-                        {t('views.instructors.courses.createCourse.editLecture.uploadAttachment')}
-                    </Button>
-                </div>
-            </section>
+            <LectureAttachmentSection
+                lecture={lecture}
+                module={module}
+                updateLecture={updateLecture}
+                onUpdateItem={updateItem}
+            />
 
             <div className="d-flex justify-content-end mt-3 gap-2">
                 <Button

--- a/frontend/src/views/instructors/courses/createCourse/LectureDetails.tsx
+++ b/frontend/src/views/instructors/courses/createCourse/LectureDetails.tsx
@@ -66,12 +66,7 @@ const LectureDetails = () => {
 
             <LectureContentSection lecture={lecture} module={module} updateLecture={updateLecture} />
 
-            <LectureAttachmentSection
-                lecture={lecture}
-                module={module}
-                updateLecture={updateLecture}
-                onUpdateItem={updateItem}
-            />
+            <LectureAttachmentSection lecture={lecture} module={module} updateLecture={updateLecture} />
 
             <div className="d-flex justify-content-end mt-3 gap-2">
                 <Button

--- a/frontend/src/views/instructors/courses/createCourse/context/CreateCourseContext.tsx
+++ b/frontend/src/views/instructors/courses/createCourse/context/CreateCourseContext.tsx
@@ -1,11 +1,11 @@
 import { createContext, ReactNode, useState } from 'react';
-import { Module, Lecture, Setter, EditTarget } from '../../types';
+import { Module, Lecture, Setter, EditTarget, Resources } from '../../types';
 
 type Props = {
     children: ReactNode;
 };
 
-type updateItemFn = <T extends Module | Lecture>(updatedItem: T, setItems: Setter<T[]>) => void;
+type updateItemFn = <T extends Module | Lecture | Resources>(updatedItem: T, setItems: Setter<T[]>) => void;
 type deleteItemFn = <T extends Module | Lecture>(id: string, setItems: Setter<T[]>) => void;
 
 type VoidStringFn = (t: string) => void;

--- a/frontend/src/views/instructors/courses/types.ts
+++ b/frontend/src/views/instructors/courses/types.ts
@@ -53,7 +53,7 @@ export type ModuleItemProps = {
     setEditingViewItem: Setter<EditTarget>;
 };
 
-export type ItemTitleProps<T extends Module | Lecture> = {
+export type ItemTitleProps<T extends Module | Lecture | Resources> = {
     item: T;
     index: number;
     isEditing: boolean;

--- a/frontend/src/views/instructors/courses/types.ts
+++ b/frontend/src/views/instructors/courses/types.ts
@@ -12,6 +12,12 @@ export type TextData = {
     content: string;
 };
 
+export type Resources = {
+    id: string;
+    title: string;
+    url: string;
+};
+
 export enum LectureType {
     TEXT = 'text',
     VIDEO = 'video',
@@ -22,6 +28,7 @@ export type Lecture = {
     title: string;
     type?: LectureType;
     content?: { video?: VideoFileData; text?: TextData };
+    resources?: Resources[];
 };
 
 export type Module = {
@@ -38,7 +45,7 @@ export type EditTarget = { id: string; type: 'module' | 'lecture' } | null;
 export type ModuleItemProps = {
     module: Module;
     index: number;
-    onUpdateItem: <T extends Module | Lecture>(updatedItem: T, setItems: Setter<T[]>) => void;
+    onUpdateItem: <T extends Module | Lecture | Resources>(updatedItem: T, setItems: Setter<T[]>) => void;
     onDeleteItem: <T extends Module | Lecture>(id: string, setItems: Setter<T[]>) => void;
     idGenerator: () => string;
     setModules: Setter<Module[]>;
@@ -72,4 +79,11 @@ export type VideoLectureContentProps = {
     handleDeleteVideo: () => void;
     isDeleting: boolean;
     toggleDeleteMode: Toggle;
+};
+
+export type LectureAttachmentSectionProps = {
+    lecture: Lecture | null;
+    module: Module | null;
+    updateLecture: (updatedLecture: Lecture) => void;
+    onUpdateItem: <T extends Module | Lecture | Resources>(updatedItem: T, setItems: Setter<T[]>) => void;
 };

--- a/frontend/src/views/instructors/courses/types.ts
+++ b/frontend/src/views/instructors/courses/types.ts
@@ -12,7 +12,7 @@ export type TextData = {
     content: string;
 };
 
-export type Resources = {
+export type Resource = {
     id: string;
     title: string;
     url: string;
@@ -28,7 +28,7 @@ export type Lecture = {
     title: string;
     type?: LectureType;
     content?: { video?: VideoFileData; text?: TextData };
-    resources?: Resources[];
+    resources?: Resource[];
 };
 
 export type Module = {
@@ -45,7 +45,7 @@ export type EditTarget = { id: string; type: 'module' | 'lecture' } | null;
 export type ModuleItemProps = {
     module: Module;
     index: number;
-    onUpdateItem: <T extends Module | Lecture | Resources>(updatedItem: T, setItems: Setter<T[]>) => void;
+    onUpdateItem: <T extends Module | Lecture | Resource>(updatedItem: T, setItems: Setter<T[]>) => void;
     onDeleteItem: <T extends Module | Lecture>(id: string, setItems: Setter<T[]>) => void;
     idGenerator: () => string;
     setModules: Setter<Module[]>;
@@ -53,7 +53,7 @@ export type ModuleItemProps = {
     setEditingViewItem: Setter<EditTarget>;
 };
 
-export type ItemTitleProps<T extends Module | Lecture | Resources> = {
+export type ItemTitleProps<T extends Module | Lecture | Resource> = {
     item: T;
     index: number;
     isEditing: boolean;
@@ -85,5 +85,4 @@ export type LectureAttachmentSectionProps = {
     lecture: Lecture | null;
     module: Module | null;
     updateLecture: (updatedLecture: Lecture) => void;
-    onUpdateItem: <T extends Module | Lecture | Resources>(updatedItem: T, setItems: Setter<T[]>) => void;
 };


### PR DESCRIPTION
Add support for uploading auxiliary attachments to a lecture.
Only allow documents (pdf, ppt, word, csv, excel) and images.
Maximum of 3 attachments per lecture.
Maximum file size of 1MB per attachment.
When uploading a file, send a request to the backend to store it, and register its filename and id in the lecture's resources field.